### PR TITLE
Device "Twickenham Scientific / Scientific Magnetics Superconducting Magnet Controller" added

### DIFF
--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -29,7 +29,7 @@ from pyqtgraph.Qt import QtGui, QtCore, loadUiType
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
-QtCore.QSignal = QtCore.pyqtSignal
+QtCore.QSignal = QtCore.Signal
 
 
 def fromUi(*args, **kwargs):
@@ -52,9 +52,11 @@ def fromUi(*args, **kwargs):
 def qt_min_version(major, minor=0):
     """
     Check for a minimum Qt version. For example, to check for version 4.11
-    or later, call ``check_qt_version(4, 11)``.
+    or later, call ``qt_min_version(4, 11)``.
 
-    :return bool: True if PyQt version >= min_version
+    :return bool: True if Python Qt bindings library version >= min_version
     """
-    return (QtCore.QT_VERSION >= ((major << 16) + (minor << 8)))
-
+    version = QtCore.qVersion().split(".")
+    version_major = int(version[0])
+    version_minor = int(version[1])
+    return (version_major > major) or ((version_major == major) and  (version_minor >= minor))

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -48,15 +48,3 @@ def fromUi(*args, **kwargs):
         if isinstance(element, QtGui.QWidget):
             setattr(widget, name, element)
     return widget
-
-def qt_min_version(major, minor=0):
-    """
-    Check for a minimum Qt version. For example, to check for version 4.11
-    or later, call ``qt_min_version(4, 11)``.
-
-    :return bool: True if Python Qt bindings library version >= min_version
-    """
-    version = QtCore.qVersion().split(".")
-    version_major = int(version[0])
-    version_minor = int(version[1])
-    return (version_major > major) or ((version_major == major) and (version_minor >= minor))

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -59,4 +59,4 @@ def qt_min_version(major, minor=0):
     version = QtCore.qVersion().split(".")
     version_major = int(version[0])
     version_minor = int(version[1])
-    return (version_major > major) or ((version_major == major) and  (version_minor >= minor))
+    return (version_major > major) or ((version_major == major) and (version_minor >= minor))

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -26,7 +26,7 @@ import logging
 
 import re
 
-from .Qt import QtCore, QtGui, qt_min_version
+from .Qt import QtCore, QtGui
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -80,18 +80,14 @@ class Input(object):
         return self._parameter
 
 
-class StringInput(QtGui.QLineEdit, Input):
+class StringInput(Input, QtGui.QLineEdit):
     """
     String input box connected to a :class:`Parameter`. Parameter subclasses
     that are string-based may also use this input, but non-string parameters
     should use more specialised input classes.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QLineEdit.__init__(self, parent=parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
 
     def setValue(self, value):
         # QtGui.QLineEdit has a setText() method instead of setValue()
@@ -105,7 +101,7 @@ class StringInput(QtGui.QLineEdit, Input):
         return super().text()
 
 
-class FloatInput(QtGui.QDoubleSpinBox, Input):
+class FloatInput(Input, QtGui.QDoubleSpinBox):
     """
     Spin input box for floating-point values, connected to a
     :class:`FloatParameter`.
@@ -115,11 +111,7 @@ class FloatInput(QtGui.QDoubleSpinBox, Input):
             For inputs in scientific notation.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QDoubleSpinBox.__init__(self, parent=parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
         self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
@@ -129,16 +121,12 @@ class FloatInput(QtGui.QDoubleSpinBox, Input):
         super().set_parameter(parameter) # default gets set here, after min/max
 
 
-class IntegerInput(QtGui.QSpinBox, Input):
+class IntegerInput(Input, QtGui.QSpinBox):
     """
     Spin input box for integer values, connected to a :class:`IntegerParameter`.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QSpinBox.__init__(self, parent=parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
         self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):
@@ -148,16 +136,12 @@ class IntegerInput(QtGui.QSpinBox, Input):
         super().set_parameter(parameter) # default gets set here, after min/max
 
 
-class BooleanInput(QtGui.QCheckBox, Input):
+class BooleanInput(Input, QtGui.QCheckBox):
     """
     Checkbox for boolean values, connected to a :class:`BooleanParameter`.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QCheckBox.__init__(self, parent=parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -174,16 +158,12 @@ class BooleanInput(QtGui.QCheckBox, Input):
         return super().isChecked()
 
 
-class ListInput(QtGui.QComboBox, Input):
+class ListInput(Input, QtGui.QComboBox):
     """
     Dropdown for list values, connected to a :class:`ListParameter`.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QComboBox.__init__(self, parent=parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
         self._stringChoices = None
         self.setEditable(False)
 
@@ -219,7 +199,7 @@ class ListInput(QtGui.QComboBox, Input):
         return self._parameter.choices[self.currentIndex()]
 
 
-class ScientificInput(QtGui.QDoubleSpinBox, Input):
+class ScientificInput(Input, QtGui.QDoubleSpinBox):
     """
     Spinner input box for floating-point values, connected to a
     :class:`FloatParameter`. This box will display and accept values in
@@ -230,11 +210,7 @@ class ScientificInput(QtGui.QDoubleSpinBox, Input):
             For a non-scientific floating-point input box.
     """
     def __init__(self, parameter, parent=None, **kwargs):
-        if qt_min_version(5):
-            super().__init__(parameter=parameter, parent=parent, **kwargs)
-        else:
-            QtGui.QDoubleSpinBox.__init__(self, parent, **kwargs)
-            Input.__init__(self, parameter)
+        super().__init__(parameter=parameter, parent=parent, **kwargs)
         self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
 
     def set_parameter(self, parameter):

--- a/pymeasure/display/log.py
+++ b/pymeasure/display/log.py
@@ -33,6 +33,13 @@ log.addHandler(logging.NullHandler())
 
 
 class LogHandler(Handler):
+    # Class Emitter is added to keep compatibility with PySide2
+    # 1. Signal needs to be class attribute of a QObject subclass
+    # 2. logging Handler emit method clashes with QObject emit method
+    # 3. As a consequence, the LogHandler cannot inherit both from
+    # Handler and QObject
+    # 4. A new utility class Emitter subclass of QObject is
+    # introduced to handle record Signal and workaround the problem
     class Emitter(QtCore.QObject):
         record = QtCore.QSignal(object)
 

--- a/pymeasure/display/log.py
+++ b/pymeasure/display/log.py
@@ -32,12 +32,16 @@ log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class LogHandler(QtCore.QObject, Handler):
-    record = QtCore.QSignal(object)
+class LogHandler(Handler):
+    class Emitter(QtCore.QObject):
+        record = QtCore.QSignal(object)
 
-    def __init__(self, parent=None):
-        QtCore.QObject.__init__(self, parent)
-        Handler.__init__(self)
+    def __init__(self):
+        super().__init__()
+        self.emitter = self.Emitter()
+
+    def connect(self, *args, **kwargs):
+        return self.emitter.record.connect(*args, **kwargs)
 
     def emit(self, record):
-        self.record.emit(self.format(record))
+        self.emitter.record.emit(self.format(record))

--- a/pymeasure/display/widgets.py
+++ b/pymeasure/display/widgets.py
@@ -530,7 +530,7 @@ class LogWidget(QtGui.QWidget):
             fmt='%(asctime)s : %(message)s (%(levelname)s)',
             datefmt='%m/%d/%Y %I:%M:%S %p'
         ))
-        self.handler.record.connect(self.view.appendPlainText)
+        self.handler.connect(self.view.appendPlainText)
 
     def _layout(self):
         vbox = QtGui.QVBoxLayout(self)

--- a/pymeasure/instruments/resources.py
+++ b/pymeasure/instruments/resources.py
@@ -47,7 +47,7 @@ def list_resources():
             # try to avoid errors from *idn?
             try:
                 # noinspection PyUnresolvedReferences
-                idn = res.ask('*idn?')[:-1]
+                idn = res.query('*idn?')[:-1]
             except pyvisa.Error:
                 idn = "Not known"
             finally:


### PR DESCRIPTION
I've added the Superconducting Magnet Controller from Twickenham Scientific (which was also distributed by ScientificMagnetics) to the Instruments-Library. Therefore, I had to slightly change the adapter-module to accept Dict-Values, as the SMU is a non-SCPI-Device and, in my opinion, the communication protocol is kind of a "Bastard Protocol From Hell"; which can be checked here: https://www.twicksci.co.uk/manuals/pdf/smc552+.pdf

I hope that this work will be useful for other scientists - but be careful: mixing up the solenoid can lead to a quench and thus, depending on the setup, to serious damage or injury! I've only tested the setter- and getter functions for the magnetic field and also the shutdown routine as I don't need other functions by the moment.